### PR TITLE
Issue111

### DIFF
--- a/src/main/java/org/ayfaar/app/controllers/search/cache/CacheTable.java
+++ b/src/main/java/org/ayfaar/app/controllers/search/cache/CacheTable.java
@@ -1,0 +1,26 @@
+package org.ayfaar.app.controllers.search.cache;
+
+
+import org.ayfaar.app.dao.CommonDao;
+
+import javax.inject.Inject;
+import java.util.List;
+
+public class CacheTable {
+
+    @Inject CommonDao commonDao;
+
+    public  void clearCacheTable(){
+
+    List<CacheEntity> cacheEntities = commonDao.getAll(CacheEntity.class);
+        for (CacheEntity cacheEntity : cacheEntities) {
+            commonDao.remove(cacheEntity);
+        }
+    }
+
+    public  void clearByURI(String uri){
+
+        commonDao.remove(CacheEntity.class,uri);
+    }
+
+}

--- a/src/main/java/org/ayfaar/app/controllers/search/cache/CacheTable.java
+++ b/src/main/java/org/ayfaar/app/controllers/search/cache/CacheTable.java
@@ -3,6 +3,7 @@ package org.ayfaar.app.controllers.search.cache;
 
 import org.ayfaar.app.dao.CommonDao;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import javax.inject.Inject;
@@ -24,7 +25,8 @@ public class CacheTable {
         }
     }
 
-    public  void clearByURI(String uri){
+    @RequestMapping("clearby/{uri}")
+    public  void clearByURI(@PathVariable String uri){
 
         commonDao.remove(CacheEntity.class,uri);
     }

--- a/src/main/java/org/ayfaar/app/controllers/search/cache/CacheTable.java
+++ b/src/main/java/org/ayfaar/app/controllers/search/cache/CacheTable.java
@@ -2,14 +2,20 @@ package org.ayfaar.app.controllers.search.cache;
 
 
 import org.ayfaar.app.dao.CommonDao;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import javax.inject.Inject;
 import java.util.List;
 
+@Controller
+@RequestMapping("api/cache")
 public class CacheTable {
 
     @Inject CommonDao commonDao;
 
+
+    @RequestMapping("clear")
     public  void clearCacheTable(){
 
     List<CacheEntity> cacheEntities = commonDao.getAll(CacheEntity.class);

--- a/src/main/java/org/ayfaar/app/controllers/search/cache/DBCache.java
+++ b/src/main/java/org/ayfaar/app/controllers/search/cache/DBCache.java
@@ -83,7 +83,7 @@ public class DBCache extends ConcurrentMapCache {
 
         if (key instanceof SearchCacheKey && ((SearchCacheKey) key).page == 0) {
             TermsMap.TermProvider provider = termsMap.getTermProvider(((SearchCacheKey) key).query);
-            if(provider != null && ((SearchCacheKey) key).page == 0) {
+            if(provider != null) {
                 uid = provider.hasMainTerm() ? provider.getMainTermProvider().getTerm() : provider.getTerm();
             }
         } else if(key instanceof ContentsCacheKey) {
@@ -101,7 +101,7 @@ public class DBCache extends ConcurrentMapCache {
     }
 
     public void clearByURI(URI uri){
-        super.evict(uri.toString());
+        super.evict(uri);
     }
 
 }

--- a/src/main/java/org/ayfaar/app/controllers/search/cache/DBCache.java
+++ b/src/main/java/org/ayfaar/app/controllers/search/cache/DBCache.java
@@ -12,6 +12,9 @@ import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.cache.support.SimpleValueWrapper;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -19,6 +22,8 @@ import java.net.URI;
 
 
 @Component
+@Controller
+@RequestMapping("api/dbcache")
 public class DBCache extends ConcurrentMapCache {
     @Inject CustomObjectMapper objectMapper;
     @Inject TermsMap termsMap;
@@ -97,11 +102,13 @@ public class DBCache extends ConcurrentMapCache {
         super.put(key, json);
     }
 
+    @RequestMapping("clear")
     public void clearAll(){
         super.clear();
     }
 
-    public void clearByURI(String uri){
+    @RequestMapping("clearby/{uri}")
+    public void clearByURI(@PathVariable String uri){
         SearchCacheKey searchKey = new SearchCacheKey(uri,0);
         super.evict(searchKey);
     }

--- a/src/main/java/org/ayfaar/app/controllers/search/cache/DBCache.java
+++ b/src/main/java/org/ayfaar/app/controllers/search/cache/DBCache.java
@@ -102,7 +102,6 @@ public class DBCache extends ConcurrentMapCache {
     }
 
     public void clearByURI(String uri){
-
         SearchCacheKey searchKey = new SearchCacheKey(uri,0);
         super.evict(searchKey);
     }

--- a/src/main/java/org/ayfaar/app/controllers/search/cache/DBCache.java
+++ b/src/main/java/org/ayfaar/app/controllers/search/cache/DBCache.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 import java.io.IOException;
+import java.net.URI;
 
 
 @Component
@@ -94,4 +95,13 @@ public class DBCache extends ConcurrentMapCache {
         }
         super.put(key, json);
     }
+
+    public void clearAll(){
+        super.clear();
+    }
+
+    public void clearByURI(URI uri){
+        super.evict(uri.toString());
+    }
+
 }

--- a/src/main/java/org/ayfaar/app/controllers/search/cache/DBCache.java
+++ b/src/main/java/org/ayfaar/app/controllers/search/cache/DBCache.java
@@ -90,6 +90,7 @@ public class DBCache extends ConcurrentMapCache {
             String name = ((ContentsCacheKey) key).categoryName;
             uid = commonDao.get(UID.class, UriGenerator.generate(Category.class, name));
         }
+
         if(uid != null) {
             commonDao.save(new CacheEntity(uid, json));
         }
@@ -100,8 +101,11 @@ public class DBCache extends ConcurrentMapCache {
         super.clear();
     }
 
-    public void clearByURI(URI uri){
-        super.evict(uri);
+    public void clearByURI(String uri){
+
+        SearchCacheKey searchKey = new SearchCacheKey(uri,0);
+        super.evict(searchKey);
     }
+
 
 }

--- a/src/test/java/issues/issue111/Issue111UnitTest.java
+++ b/src/test/java/issues/issue111/Issue111UnitTest.java
@@ -1,0 +1,31 @@
+package issues.issue111;
+
+import org.ayfaar.app.controllers.search.cache.CacheEntity;
+import org.ayfaar.app.controllers.search.cache.CacheTable;
+import org.ayfaar.app.controllers.search.cache.DBCache;
+import org.ayfaar.app.dao.CommonDao;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.inject.Inject;
+
+public class Issue111UnitTest {
+
+    @Inject
+    DBCache dbCache;
+    @Inject
+    CommonDao commonDao;
+
+    @Test
+    public void ClearDBCache(){
+        dbCache.clearAll();
+        Assert.assertEquals(dbCache, new DBCache());
+    }
+
+    public void ClearCachTable(){
+        CacheTable cacheTable = new CacheTable();
+        cacheTable.clearCacheTable();
+        Assert.assertEquals(commonDao.getAll(CacheEntity.class),0);
+    }
+    
+}


### PR DESCRIPTION
   The method ("clearCacheTable") which clear all cache is not a good way, cuz it uses a lot of requests. MayBe Hibernate will combine into one request? If not - I think we have to create a new DAO which will have the method - removeAll() or removeSomeProperty(String proprty). 
 CacheTable.java - shoud be a static call and we will transfer model and/or dao.
 uri is equals id  in a method clearByURI?
